### PR TITLE
The escape() issue with languages like Tamil

### DIFF
--- a/js/jquery.formbuilder.js
+++ b/js/jquery.formbuilder.js
@@ -476,19 +476,19 @@
 						serialStr += opts.prepend + '[' + li_count + '][required]=' + escape($('#' + $(this).attr('id') + ' input.required').attr('checked'));
 						switch ($(this).attr(opts.attributes[att])) {
 						case 'input_text':
-							serialStr += opts.prepend + '[' + li_count + '][values]=' + escape($('#' + $(this).attr('id') + ' input[type=text]').val());
+							serialStr += opts.prepend + '[' + li_count + '][values]=' + encodeURIComponent($('#' + $(this).attr('id') + ' input[type=text]').val());
 							break;
 						case 'textarea':
-							serialStr += opts.prepend + '[' + li_count + '][values]=' + escape($('#' + $(this).attr('id') + ' input[type=text]').val());
+							serialStr += opts.prepend + '[' + li_count + '][values]=' + encodeURIComponent($('#' + $(this).attr('id') + ' input[type=text]').val());
 							break;
 						case 'checkbox':
 							c = 1;
 							$('#' + $(this).attr('id') + ' input[type=text]').each(function () {
 								if ($(this).attr('name') === 'title') {
-									serialStr += opts.prepend + '[' + li_count + '][title]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][title]=' + encodeURIComponent($(this).val());
 								}
 								else {
-									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + encodeURIComponent($(this).val());
 									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][default]=' + $(this).prev().attr('checked');
 								}
 								c++;
@@ -498,10 +498,10 @@
 							c = 1;
 							$('#' + $(this).attr('id') + ' input[type=text]').each(function () {
 								if ($(this).attr('name') === 'title') {
-									serialStr += opts.prepend + '[' + li_count + '][title]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][title]=' + encodeURIComponent($(this).val());
 								}
 								else {
-									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + encodeURIComponent($(this).val());
 									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][default]=' + $(this).prev().attr('checked');
 								}
 								c++;
@@ -512,10 +512,10 @@
 							serialStr += opts.prepend + '[' + li_count + '][multiple]=' + $('#' + $(this).attr('id') + ' input[name=multiple]').attr('checked');
 							$('#' + $(this).attr('id') + ' input[type=text]').each(function () {
 								if ($(this).attr('name') === 'title') {
-									serialStr += opts.prepend + '[' + li_count + '][title]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][title]=' + encodeURIComponent($(this).val());
 								}
 								else {
-									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + escape($(this).val());
+									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][value]=' + encodeURIComponent($(this).val());
 									serialStr += opts.prepend + '[' + li_count + '][values][' + c + '][default]=' + $(this).prev().attr('checked');
 								}
 								c++;


### PR DESCRIPTION
I replaced `escape()` with `encodeURIComponent()` to ensure compatibility with `urldecode()`, the reason for that is if the content is in Islamic or some other Indian continent language, `escape()` will encode the string in a way you can't (or hardly) will be able to decode server-side in PHP.

`encodeURIComponent()` on the other hand will do the `escape()` job but will ensure compatibility with PHP `urldecode()`.

For an use-case, use the word `தமிழ்` (taken from http://en.wikipedia.org/wiki/Tamil_language) and test it in this page to see the difference between the javascript and PHP functions.

Thanks.
