### PR TITLE
fixed sorting

### DIFF
--- a/css/jquery.formbuilder.css
+++ b/css/jquery.formbuilder.css
@@ -20,7 +20,7 @@ ul.frmb {
 	background: #FFFEEB;
 }
 
-.frmb .legend {
+.ui-sortable > li {
 	cursor: move;
 }
 

--- a/js/jquery.formbuilder.js
+++ b/js/jquery.formbuilder.js
@@ -45,7 +45,7 @@
 		var opts = $.extend(defaults, options);
 		var frmb_id = 'frmb-' + $('ul[id^=frmb-]').length++;
 		return this.each(function () {
-			var ul_obj = $(this).append('<ul id="' + frmb_id + '" class="frmb"></ul>').find('ul');
+			var ul_obj = $(this).append('<ul id="' + frmb_id + '" class="frmb"></ul>').find('ul').sortable();
 			var field = '', field_type = '', last_id = 1, help, form_db_id;
 			// Add a unique class to the current element
 			$(ul_obj).addClass(frmb_id);


### PR DESCRIPTION
After realizing that sorting worked on checkboxes, radios, and selects. I noticed that the css selector was only targeting the label with the move cursor, making the appearance that you could re sort actual inputs and not values in checkboxes/radios/selects.

so i tossed in a .sortable() on the main ul, and fixed the selector, now you can sort both inputs and also values in checkboxes/radios/selects
