### PR TITLE
Update formrunner.js, formbuilder.js

### DIFF
--- a/src/js/formrunner.js
+++ b/src/js/formrunner.js
@@ -42,6 +42,7 @@ var Formrunner = function(opts){
   if( dust.onLoad === undefined ){
     dust.onLoad = function(name, callback) {
       $.ajax(_privateSelf._opts.templateBasePath + '/' + name + '.tpl', {
+        async:false,
         success: function(data) {
           callback(undefined, data);
         },


### PR DESCRIPTION
use a sync call so when the templates are dynamically loaded the order persistes
